### PR TITLE
Removed the limit_choices_to foreignkey constraint

### DIFF
--- a/backend/dpi_app/models.py
+++ b/backend/dpi_app/models.py
@@ -72,7 +72,7 @@ class Doctor(models.Model):
 class Consultation(models.Model):
     id = models.AutoField(primary_key=True)
     dpi = models.ForeignKey(Dpi, on_delete=models.CASCADE)
-    doctor = models.ForeignKey(Staff, on_delete=models.CASCADE, limit_choices_to={"role": "Doctor"})
+    doctor = models.ForeignKey(Staff, on_delete=models.CASCADE)
     consultation_summary = models.TextField()
     examination_required = models.TextField()
     hospital = models.TextField()
@@ -107,7 +107,7 @@ class Medicine(models.Model):
 class BiologicalExam(models.Model):
     id = models.AutoField(primary_key=True)
     consultation = models.ForeignKey(Consultation, on_delete=models.CASCADE)
-    lab_technician = models.ForeignKey(Staff, on_delete=models.CASCADE, limit_choices_to={"role": "LabTechnician"})
+    lab_technician = models.ForeignKey(Staff, on_delete=models.CASCADE)
     exam_name = models.CharField(max_length=100)
     result = models.TextField()
     has_graph = models.BooleanField(default=False)
@@ -132,7 +132,7 @@ class BiologicalExamParam(models.Model):
 class RadiologicalExam(models.Model):
     id = models.AutoField(primary_key=True)
     consultation = models.ForeignKey(Consultation, on_delete=models.CASCADE)
-    radiologist = models.ForeignKey(Staff, on_delete=models.CASCADE, limit_choices_to={"role": "Radiologist"})
+    radiologist = models.ForeignKey(Staff, on_delete=models.CASCADE)
     exam_name = models.TextField()
     image_url = models.TextField()
     result = models.TextField()
@@ -145,7 +145,7 @@ class RadiologicalExam(models.Model):
 class NursingRecord(models.Model):
     id = models.AutoField(primary_key=True)
     consultation = models.ForeignKey(Consultation, on_delete=models.CASCADE)
-    nurse = models.ForeignKey(Staff, on_delete=models.CASCADE, limit_choices_to={"role": "Nurse"})
+    nurse = models.ForeignKey(Staff, on_delete=models.CASCADE)
     care_name = models.TextField()
     patient_observation = models.TextField()
     record_date = models.DateTimeField(default=timezone.now)


### PR DESCRIPTION
The `limit_choices_to` argument in a `ForeignKey` field adds a filter to restrict the `queryset` used by Django's ORM to validate or fetch the related object.
The ORM raises a `ValidationError` with the message "Invalid pk \"8\" - object does not exist." because it could not find a matching object under the imposed constraint.
Our serializers' custom validators for example : `validate_doctor`, will raise better errors in these cases.